### PR TITLE
The flashpoint paradox

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "xshifty/my-php-merge",
+    "name": "consultormarcelobrito/database-merge",
     "description": "PHP MySQL merge schema",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "consultormarcelobrito/database-merge",
+    "name": "xshifty/my-php-merge",
     "description": "PHP MySQL merge schema",
     "authors": [
         {

--- a/src/Actions/AccumulateMergeData.php
+++ b/src/Actions/AccumulateMergeData.php
@@ -14,8 +14,7 @@ final class AccumulateMergeData implements Action
         Rule $mergeRule,
         MysqlConnection $sourceConnection,
         MysqlConnection $groupConnection
-    )
-    {
+    ) {
         $this->mergeRule = $mergeRule;
         $this->sourceConnection = $sourceConnection;
         $this->groupConnection = $groupConnection;

--- a/src/Actions/FlatDuplicateData.php
+++ b/src/Actions/FlatDuplicateData.php
@@ -1,0 +1,105 @@
+<?php
+namespace Xshifty\MyPhpMerge\Actions;
+
+use Xshifty\MyPhpMerge\Merge\Rules\Rule;
+use Xshifty\MyPhpMerge\Schema\MysqlConnection;
+
+final class FlatDuplicateData implements Action
+{
+    private $mergeRule;
+    private $sourceConnection;
+    private $groupConnection;
+
+    public function __construct(
+        Rule $mergeRule,
+        MysqlConnection $sourceConnection,
+        MysqlConnection $groupConnection
+    ) {
+        $this->mergeRule = $mergeRule;
+        $this->sourceConnection = $sourceConnection;
+        $this->groupConnection = $groupConnection;
+    }
+
+    public function execute()
+    {
+        echo '.';
+
+        $this->groupConnection->execute(sprintf(
+            'DROP TABLE IF EXISTS `myphpmerge_%s_flat`',
+            $this->mergeRule->table
+        ));
+
+        $accumColumnsDescription = $this->groupConnection->query("DESCRIBE myphpmerge_{$this->mergeRule->table}");
+        $accumPrimaryKey = array_reduce($accumColumnsDescription, function ($initial, $current) {
+            if (!empty($initial['Key']) && $initial['Key'] == 'PRI') {
+                return $initial;
+            }
+
+            if (!empty($current['Key']) && $current['Key'] == 'PRI') {
+                $initial = $current;
+                return $initial;
+            }
+        });
+        $accumColumnsName = array_map(function ($row) {
+            return $row['Field'];
+        }, $accumColumnsDescription);
+
+        $accumColumnsNameOriginal = $accumColumnsName;
+
+        $unique = !empty($this->mergeRule->unique) ? $this->mergeRule->unique : [];
+        $foreignKeys = $this->mergeRule->foreignKeys;
+        $table = $this->mergeRule->table;
+        $accumColumnsName = array_map(function ($row) use ($accumPrimaryKey, $unique, $foreignKeys, $table) {
+
+            $maxRow = $row;
+            $isUnique = count($unique);
+            $isForeignKey = array_search($row, array_column($foreignKeys, 'key'));
+
+            if ($isUnique) {
+                $maxRow = "MAX({$row}) AS '{$row}'";
+            }
+
+            if ('myphpmerge__key__' == $row && $isUnique) {
+                return "GROUP_CONCAT(DISTINCT myphpmerge__key__) AS myphpmerge__key__";
+            }
+
+            if ($isForeignKey && $isUnique) {
+                $this->groupConnection->execute("ALTER TABLE `myphpmerge_{$table}` CHANGE `{$row}` `{$row}` VARCHAR(255) NULL DEFAULT NULL;");
+                return "GROUP_CONCAT(DISTINCT {$row}) AS {$row}";
+            }
+
+            return $maxRow;
+        }, $accumColumnsName);
+        $accumColumnsName = array_filter($accumColumnsName);
+
+        $sql = sprintf(
+            '
+            CREATE TABLE `myphpmerge_%1$s_flat` (
+                    SELECT      %3$s
+                    FROM        `myphpmerge_%1$s`
+                    %4$s
+                    ORDER BY    LPAD(`myphpmerge__key__`, 10, "0") ASC
+                )
+            ',
+            $this->mergeRule->table,
+            implode(', ', $accumColumnsNameOriginal),
+            implode(', ', $accumColumnsName),
+            !empty($this->mergeRule->unique) && count($this->mergeRule->unique)
+            ? 'GROUP BY ' . implode(', ', $this->mergeRule->unique) : ''
+        );
+
+        $this->groupConnection->execute($sql);
+
+        $this->groupConnection->execute(sprintf(
+            'DROP TABLE `myphpmerge_%s`',
+            $this->mergeRule->table
+        ));
+
+        $this->groupConnection->execute(sprintf(
+            'RENAME TABLE `myphpmerge_%s_flat` TO `myphpmerge_%s`;',
+            $this->mergeRule->table,
+            $this->mergeRule->table
+        ));
+
+    }
+}

--- a/src/Actions/FlatDuplicateData.php
+++ b/src/Actions/FlatDuplicateData.php
@@ -95,12 +95,13 @@ final class FlatDuplicateData implements Action
                     OR @%1$s LIKE CONCAT(\'%%,\', myphpmerge__key__)
                 ), 1)';
 
+        $flatForce = isset($this->mergeRule->flatForce) ? $this->mergeRule->flatForce : false;
         $count = count($this->mergeRule->unique) ? ', count(myphpmerge__key__) q' : '';
         $selectTemplate = '
                 (SELECT %1$s
                     ' . $count . '
                     FROM `myphpmerge_%2$s`
-                ' . $uniques . '
+                ' . ($flatForce ? 'GROUP BY %%1$s' : $uniques) . '
                 HAVING %%1$s
                     ' . ($count ? ' AND q > 1 ' : '') . ')';
 

--- a/src/Actions/FlatDuplicateData.php
+++ b/src/Actions/FlatDuplicateData.php
@@ -100,7 +100,7 @@ final class FlatDuplicateData implements Action
                 (SELECT %1$s
                     ' . $count . '
                     FROM `myphpmerge_%2$s`
-                GROUP BY %%1$s
+                ' . $uniques . '
                 HAVING %%1$s
                     ' . ($count ? ' AND q > 1 ' : '') . ')';
 

--- a/src/Actions/FlatDuplicateData.php
+++ b/src/Actions/FlatDuplicateData.php
@@ -61,6 +61,14 @@ final class FlatDuplicateData implements Action
                 return "@%1\$s := GROUP_CONCAT(DISTINCT myphpmerge__key__) AS myphpmerge_grouped_keys";
             }
 
+            if ('id' == $row && $isUnique) {
+                return "GROUP_CONCAT(DISTINCT id) AS id";
+            }
+
+            if ('myphpmerge_schema' == $row && $isUnique) {
+                return "GROUP_CONCAT(DISTINCT myphpmerge_schema) AS myphpmerge_schema";
+            }
+
             if ('myphpmerge__key__' == $row && $isUnique) {
                 return "MIN(myphpmerge__key__) AS myphpmerge__key__";
             }

--- a/src/Actions/FlatDuplicateDataSecondFactor.php
+++ b/src/Actions/FlatDuplicateDataSecondFactor.php
@@ -1,0 +1,121 @@
+<?php
+namespace Xshifty\MyPhpMerge\Actions;
+
+use Xshifty\MyPhpMerge\Merge\Rules\Rule;
+use Xshifty\MyPhpMerge\Schema\MysqlConnection;
+
+final class FlatDuplicateDataSecondFactor implements Action
+{
+    private $mergeRule;
+    private $groupConnection;
+
+    public function __construct(
+        Rule $mergeRule,
+        MysqlConnection $groupConnection
+    ) {
+        $this->mergeRule = $mergeRule;
+        $this->groupConnection = $groupConnection;
+    }
+
+    public function execute()
+    {
+        echo '.';
+
+        $this->groupConnection->execute(sprintf(
+            'DROP TABLE IF EXISTS `myphpmerge_%s_flat`',
+            $this->mergeRule->table
+        ));
+
+        $accumColumnsDescription = $this->groupConnection->query("DESCRIBE myphpmerge_{$this->mergeRule->table}");
+        $accumPrimaryKey = array_reduce($accumColumnsDescription, function ($initial, $current) {
+            if (!empty($initial['Key']) && $initial['Key'] == 'PRI') {
+                return $initial;
+            }
+
+            if (!empty($current['Key']) && $current['Key'] == 'PRI') {
+                $initial = $current;
+                return $initial;
+            }
+        });
+        $accumColumnsName = array_map(function ($row) {
+            return $row['Field'];
+        }, $accumColumnsDescription);
+
+        $accumColumnsNameOriginal = $accumColumnsName;
+
+        $unique = !empty($this->mergeRule->unique) ? $this->mergeRule->unique : [];
+        $foreignKeys = $this->mergeRule->foreignKeys;
+        $table = $this->mergeRule->table;
+        $originalAccumColumnsName = $accumColumnsName;
+        $accumColumnsName = array_map(function ($row) use ($accumPrimaryKey, $unique, $foreignKeys, $table) {
+
+            $maxRow = $row;
+            $isUnique = count($unique);
+            $isForeignKey = array_search($row, array_column($foreignKeys, 'key'));
+
+            if ($isUnique) {
+                $maxRow = "MAX({$row}) AS '{$row}'";
+            }
+
+            if ('myphpmerge_grouped_keys' == $row && $isUnique) {
+                return "GROUP_CONCAT(DISTINCT myphpmerge__key__) AS myphpmerge_grouped_keys";
+            }
+
+            if ('id' == $row && $isUnique) {
+                return "GROUP_CONCAT(DISTINCT id) AS id";
+            }
+
+            if ('myphpmerge_schema' == $row && $isUnique) {
+                return "GROUP_CONCAT(DISTINCT myphpmerge_schema) AS myphpmerge_schema";
+            }
+
+            if ('myphpmerge__key__' == $row && $isUnique) {
+                return "MIN(myphpmerge__key__) AS myphpmerge__key__";
+            }
+
+            if ($isForeignKey && $isUnique) {
+                $this->groupConnection->execute("ALTER TABLE `myphpmerge_{$table}` CHANGE `{$row}` `{$row}` VARCHAR(255) NULL DEFAULT NULL;");
+                return "GROUP_CONCAT(DISTINCT {$row}) AS {$row}";
+            }
+
+            return $maxRow;
+        }, $accumColumnsName);
+        $accumColumnsName = array_filter($accumColumnsName);
+
+        $table = $this->mergeRule->table;
+        $accumColumnsNameOriginal = implode(', ', $accumColumnsNameOriginal);
+        $accumColumnsName = implode(', ', $accumColumnsName);
+        $uniques = !empty($this->mergeRule->unique) && count($this->mergeRule->unique)
+        ? 'GROUP BY ' . implode(', ', $this->mergeRule->unique) : '';
+
+        $count = count($this->mergeRule->unique) ? ', count(myphpmerge__key__) qq' : '';
+        $sql = '
+                (SELECT ' . $accumColumnsName . '
+                    ' . $count . '
+                FROM `myphpmerge_' . $table . '`
+                ' . $uniques . '
+                ORDER BY LPAD(`myphpmerge__key__`, 10, "0") ASC)';
+
+        $sql = sprintf(
+            '
+            CREATE TABLE `myphpmerge_%1$s_flat` %2$s
+            ',
+            $table,
+            $sql
+        );
+
+        $this->groupConnection->execute($sql);
+
+        $this->groupConnection->execute(sprintf(
+            'DROP TABLE `myphpmerge_%s`',
+            $this->mergeRule->table
+        ));
+
+        $this->groupConnection->execute(sprintf(
+            'RENAME TABLE `myphpmerge_%s_flat` TO `myphpmerge_%s`;',
+            $this->mergeRule->table,
+            $this->mergeRule->table
+        ));
+
+    }
+}

--- a/src/Actions/FlatDuplicateDataSecondFactor.php
+++ b/src/Actions/FlatDuplicateDataSecondFactor.php
@@ -88,10 +88,8 @@ final class FlatDuplicateDataSecondFactor implements Action
         $uniques = !empty($this->mergeRule->unique) && count($this->mergeRule->unique)
         ? 'GROUP BY ' . implode(', ', $this->mergeRule->unique) : '';
 
-        $count = count($this->mergeRule->unique) ? ', count(myphpmerge__key__) qq' : '';
         $sql = '
                 (SELECT ' . $accumColumnsName . '
-                    ' . $count . '
                 FROM `myphpmerge_' . $table . '`
                 ' . $uniques . '
                 ORDER BY LPAD(`myphpmerge__key__`, 10, "0") ASC)';

--- a/src/Actions/PrepareTable.php
+++ b/src/Actions/PrepareTable.php
@@ -60,6 +60,7 @@ final class PrepareTable implements Action
         $alterSql = sprintf('
             ALTER TABLE `myphpmerge_%1$s`
                 ADD COLUMN `myphpmerge_schema` VARCHAR(50) FIRST,
+                ADD COLUMN `myphpmerge_grouped_keys` VARCHAR(1000) FIRST,
                 ADD COLUMN `myphpmerge__key__` VARCHAR(1000) FIRST,
                 ADD COLUMN `myphpmerge_%2$s` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT FIRST,
                 ADD PRIMARY KEY (`myphpmerge_%2$s`)

--- a/src/Actions/PrepareTable.php
+++ b/src/Actions/PrepareTable.php
@@ -14,8 +14,7 @@ final class PrepareTable implements Action
         Rule $mergeRule,
         MysqlConnection $templateConnection,
         MysqlConnection $groupConnection
-    )
-    {
+    ) {
         $this->mergeRule = $mergeRule;
         $this->templateConnection = $templateConnection;
         $this->groupConnection = $groupConnection;

--- a/src/Actions/UpdateForeignKeys.php
+++ b/src/Actions/UpdateForeignKeys.php
@@ -1,11 +1,10 @@
 <?php
 namespace Xshifty\MyPhpMerge\Actions;
 
-use \Xshifty\MyPhpMerge\Merge\Rules\MergeRule;
-use \Xshifty\MyPhpMerge\Schema\MysqlConnection;
-use \Xshifty\MyPhpMerge\Schema\Table\TableBase;
 use \Xshifty\MyPhpMerge\Merge\Rules\RuleContainer;
+use \Xshifty\MyPhpMerge\Schema\MysqlConnection;
 use \Xshifty\MyPhpMerge\Schema\Table\ForeignKey;
+use \Xshifty\MyPhpMerge\Schema\Table\TableBase;
 
 final class UpdateForeignKeys implements Action
 {
@@ -17,8 +16,7 @@ final class UpdateForeignKeys implements Action
         TableBase $table,
         MysqlConnection $groupConnection,
         RuleContainer $ruleContainer
-    )
-    {
+    ) {
         $this->table = $table;
         $this->groupConnection = $groupConnection;
         $this->ruleContainer = $ruleContainer;
@@ -34,33 +32,13 @@ final class UpdateForeignKeys implements Action
 
     private function doUpdate(ForeignKey $key)
     {
-        $this->groupConnection->execute(sprintf(
-            'DROP TABLE IF EXISTS fkey_myphpmerge_%1$s',
-            $key->getParentTable()
-        ));
-
-        $this->groupConnection->execute(sprintf(
-            '
-            CREATE TABLE fkey_myphpmerge_%1$s (
-                SELECT * FROM myphpmerge_%1$s
-            )
-            ',
-            $key->getParentTable()
-        ));
-
-        $sql = sprintf(
-            '
-                UPDATE  myphpmerge_%1$s A, fkey_myphpmerge_%2$s B
-                SET     A.%3$s = B.myphpmerge__key__
-                WHERE   B.%4$s = A.%3$s
-                AND     A.myphpmerge_schema = B.myphpmerge_schema
-            ',
-
-            $key->getTable(),
-            $key->getParentTable(),
-            $key->getName(),
-            $key->getParentColumn()
-        );
+        $sql = "UPDATE myphpmerge_{$key->getTable()} A, myphpmerge_{$key->getParentTable()} B
+            SET    A.{$key->getName()} = B.myphpmerge__key__
+            WHERE  (
+                A.{$key->getName()} LIKE CONCAT('%,',B.{$key->getParentColumn()},',%')
+                OR A.{$key->getName()} LIKE CONCAT(B.{$key->getParentColumn()},',%')
+                OR A.{$key->getName()} LIKE CONCAT('%,',B.{$key->getParentColumn()})
+            )";
 
         $updated = $this->groupConnection->execute($sql);
         $status = '.';
@@ -68,10 +46,5 @@ final class UpdateForeignKeys implements Action
             $status = '<error>!</error>';
         }
         cprint($status);
-
-        $this->groupConnection->execute(sprintf(
-            'DROP TABLE fkey_myphpmerge_%1$s',
-            $key->getParentTable()
-        ));
     }
 }

--- a/src/Actions/UpdateForeignKeys.php
+++ b/src/Actions/UpdateForeignKeys.php
@@ -35,9 +35,13 @@ final class UpdateForeignKeys implements Action
         $sql = "UPDATE myphpmerge_{$key->getTable()} A, myphpmerge_{$key->getParentTable()} B
             SET    A.{$key->getName()} = B.myphpmerge__key__
             WHERE  (
-                A.{$key->getName()} LIKE CONCAT('%,',B.{$key->getParentColumn()},',%')
-                OR A.{$key->getName()} LIKE CONCAT(B.{$key->getParentColumn()},',%')
-                OR A.{$key->getName()} LIKE CONCAT('%,',B.{$key->getParentColumn()})
+                REPLACE(B.{$key->getParentColumn()}, ',', '|')
+                REGEXP REPLACE(CONCAT('^', A.{$key->getName()}, '$'), ',', '$|^')
+                OR
+                REPLACE(A.{$key->getName()}, ',', '|')
+                REGEXP REPLACE(CONCAT('^', B.{$key->getParentColumn()}, '$'), ',', '$|^')
+                OR
+                A.{$key->getName()} = B.{$key->getParentColumn()}
             )";
 
         $updated = $this->groupConnection->execute($sql);

--- a/src/Actions/UpdatePrimaryKeys.php
+++ b/src/Actions/UpdatePrimaryKeys.php
@@ -53,23 +53,14 @@ final class UpdatePrimaryKeys implements Action
         $sql = sprintf(
             '
                 UPDATE myphpmerge_%1$s A
-                SET A.myphpmerge__key__ = (
-                    SELECT %5$s
-                    FROM pkey_myphpmerge_%1$s B
-                    %3$s
-                    %4$s
-                    ORDER BY B.myphpmerge_%2$s
-                    LIMIT 1
-                )
+                SET A.myphpmerge__key__ = A.%2$s
             ',
             $this->table->getName(),
-            $this->table->getPrimaryKey()->getName(),
-            $where,
-            $group,
             $keyReplace
         );
 
         $updated = $this->groupConnection->execute($sql);
+
         $status = '.';
         if (!$updated) {
             $status = '<error>!</error>';

--- a/src/Actions/UpdatePrimaryKeys.php
+++ b/src/Actions/UpdatePrimaryKeys.php
@@ -1,10 +1,9 @@
 <?php
 namespace Xshifty\MyPhpMerge\Actions;
 
-use \Xshifty\MyPhpMerge\Merge\Rules\MergeRule;
+use \Xshifty\MyPhpMerge\Merge\Rules\RuleContainer;
 use \Xshifty\MyPhpMerge\Schema\MysqlConnection;
 use \Xshifty\MyPhpMerge\Schema\Table\TableBase;
-use \Xshifty\MyPhpMerge\Merge\Rules\RuleContainer;
 
 final class UpdatePrimaryKeys implements Action
 {
@@ -16,8 +15,7 @@ final class UpdatePrimaryKeys implements Action
         TableBase $table,
         MysqlConnection $groupConnection,
         RuleContainer $ruleContainer
-    )
-    {
+    ) {
         $this->table = $table;
         $this->groupConnection = $groupConnection;
         $this->ruleContainer = $ruleContainer;
@@ -48,11 +46,9 @@ final class UpdatePrimaryKeys implements Action
             $this->ruleContainer->getRule($this->table->getName())->unique
         );
 
-
-
         $pkey = $this->table->getPrimaryKey();
         $keyReplace = $pkey->getType() != 'INTEGER'
-            ? 'myphpmerge__key__' : 'myphpmerge_' . $pkey->getName();
+        ? 'myphpmerge__key__' : 'myphpmerge_' . $pkey->getName();
 
         $sql = sprintf(
             '

--- a/src/Tools/Merge.php
+++ b/src/Tools/Merge.php
@@ -68,6 +68,14 @@ final class Merge
         $this->foreachRule([$this, 'updateForeignKeys']);
         echo PHP_EOL;
 
+        cprint("<info>Flatting table data</info>");
+        $this->foreachRule([$this, 'flatDuplicateDataSecondFactor']);
+        echo PHP_EOL;
+
+        cprint("<info>Updating foreign keys</info>");
+        $this->foreachRule([$this, 'updateForeignKeys']);
+        echo PHP_EOL;
+
         cprint("<info>Moving data</info>");
         $this->foreachRule([$this, 'moveMergeData']);
         echo PHP_EOL;
@@ -249,6 +257,17 @@ final class Merge
     {
 
         $moveAction = new \Xshifty\MyPhpMerge\Actions\FlatDuplicateData(
+            $rule,
+            $this->groupConnection
+        );
+
+        $moveAction->execute();
+    }
+
+    private function flatDuplicateDataSecondFactor(Rule $rule)
+    {
+
+        $moveAction = new \Xshifty\MyPhpMerge\Actions\FlatDuplicateDataSecondFactor(
             $rule,
             $this->groupConnection
         );

--- a/src/Tools/Merge.php
+++ b/src/Tools/Merge.php
@@ -76,6 +76,17 @@ final class Merge
         $this->foreachRule([$this, 'updateForeignKeys']);
         echo PHP_EOL;
 
+        $countTables = count($this->config->schemas->source);
+        for ($i = 0; $i <= $countTables; $i++) {
+            cprint("<info>Flatting table data</info>");
+            $this->foreachRule([$this, 'flatDuplicateDataSecondFactor']);
+            echo PHP_EOL;
+
+            cprint("<info>Updating foreign keys</info>");
+            $this->foreachRule([$this, 'updateForeignKeys']);
+            echo PHP_EOL;
+        }
+
         cprint("<info>Moving data</info>");
         $this->foreachRule([$this, 'moveMergeData']);
         echo PHP_EOL;

--- a/src/Tools/Merge.php
+++ b/src/Tools/Merge.php
@@ -228,19 +228,13 @@ final class Merge
 
     private function flatDuplicateData(Rule $rule)
     {
-        if (!in_array(RuleContainer::MERGE_INTERFACE, class_implements(get_class($rule)))) {
-            return;
-        }
 
-        $this->foreachSourceConnection($closure = \Closure::bind(function (MysqlConnection $sourceConnection) use ($rule) {
-            $moveAction = new \Xshifty\MyPhpMerge\Actions\FlatDuplicateData(
-                $rule,
-                $sourceConnection,
-                $this->groupConnection
-            );
+        $moveAction = new \Xshifty\MyPhpMerge\Actions\FlatDuplicateData(
+            $rule,
+            $this->groupConnection
+        );
 
-            $moveAction->execute();
-        }, $this, $this));
+        $moveAction->execute();
     }
 
     private function cleanUp(Rule $rule)

--- a/src/Tools/Merge.php
+++ b/src/Tools/Merge.php
@@ -56,6 +56,10 @@ final class Merge
         $this->foreachRule([$this, 'updatePrimaryKeys']);
         echo PHP_EOL;
 
+        cprint("<info>Preparing foreign keys</info>");
+        $this->foreachRule([$this, 'prepareForeignKeys']);
+        echo PHP_EOL;
+
         cprint("<info>Flatting table data</info>");
         $this->foreachRule([$this, 'flatDuplicateData']);
         echo PHP_EOL;
@@ -192,6 +196,21 @@ final class Merge
         );
 
         $updateForeignKeysAction->execute();
+    }
+
+    private function PrepareForeignKeys(Rule $rule)
+    {
+        if (!in_array(RuleContainer::MERGE_INTERFACE, class_implements(get_class($rule)))) {
+            return;
+        }
+
+        $prepareForeignKeysAction = new \Xshifty\MyPhpMerge\Actions\PrepareForeignKeys(
+            $this->tableAssembler->assembly($rule),
+            $this->groupConnection,
+            $this->ruleContainer
+        );
+
+        $prepareForeignKeysAction->execute();
     }
 
     private function applyCreateRules(Rule $rule)


### PR DESCRIPTION
Desculpa pelo noma da PR =p. Não consegui em pensar em nenhum titulo...

Mas vamos lá, depois do seu ponto de partida que foi muito bem pensando e estruturado, ficou algumas coisas que estavam inconsistentes, como a perda de registro com primary keys e unique fields duplicados.

Foi feito uma correção na hora de unir os dados repetidos, criando uma camada apenas para isso, com isso surgiu alguns outros problemas, que foi preciso redefinir o esquema de primary keys e foreign key.

O que de quebra resolvi um problema de substituição de IDs que não eram incrementais como os UUIDs. Pra resolver o problema dos uuids foi necessário adicionar um novo atributo nas regras: `public $autoIncrement = false;`, o default é `true`.

Os foreign key foi necessário acrescentar o atributo `public $flatForce = true;`, default `false`, para forçar a uninão de registros duplicados em casos extremos.

Na camada de união de duplicados, foi necessário passar mais de 1x pois ele gerava duplicados conforme a quantia de bancos configurados.

Não está nada legal o código, apenas emendei o que vc tinha começado, mas com essas alterações conseguimos fazer um merge bem preciso, claro que não precisa aceitar a PR, a fiz para registro, e aqui tem um caminho pra total funcionamento sem problemas e serve de estudos futuros para uma melhor aplicação da solução.
